### PR TITLE
Allow setting implementation of IServiceProvider used in ServerBuilder

### DIFF
--- a/Networker/Client/Abstractions/IClient.cs
+++ b/Networker/Client/Abstractions/IClient.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Net.Sockets;
-using Networker.Common;
 
 namespace Networker.Client.Abstractions
 {

--- a/Networker/Client/Abstractions/IClientBuilder.cs
+++ b/Networker/Client/Abstractions/IClientBuilder.cs
@@ -1,34 +1,14 @@
-﻿using System;
-using Microsoft.Extensions.DependencyInjection;
-using Networker.Common;
-using Networker.Common.Abstractions;
+﻿using Networker.Common.Abstractions;
 
 namespace Networker.Client.Abstractions
 {
-    public interface IClientBuilder
+    public interface IClientBuilder : IBuilder<IClientBuilder, IClient>
     {
-        IClient Build();
-
-        IClientBuilder RegisterPacketHandler<TPacket, TPacketHandler>()
-            where TPacket: class where TPacketHandler: IPacketHandler;
-
-        IClientBuilder RegisterPacketHandlerModule<T>()
-            where T: IPacketHandlerModule;
-
-        IClientBuilder SetLogLevel(LogLevel logLevel);
-
-        IClientBuilder UseIp(string ip);
-
-        IClientBuilder UseLogger<T>()
-            where T: class, ILogger;
-
-        IClientBuilder UseLogger(ILogger logger);
-        IClientBuilder UseTcp(int port);
+        //Udp
         IClientBuilder UseUdp(int port, int localPort);
-        IClientBuilder UseUdp(int port);
-        IClientBuilder SetPacketBufferSize(int size);
+
+        //Info
         IClientBuilder SetPacketBufferPoolSize(int size);
-        IServiceCollection GetServiceCollection();
-        IClientBuilder SetServiceCollection(IServiceCollection serviceCollection, Func<IServiceProvider> serviceProviderFactory = null);
+        IClientBuilder UseIp(string ip);
     }
 }

--- a/Networker/Client/Abstractions/IClientBuilder.cs
+++ b/Networker/Client/Abstractions/IClientBuilder.cs
@@ -29,5 +29,6 @@ namespace Networker.Client.Abstractions
         IClientBuilder SetPacketBufferSize(int size);
         IClientBuilder SetPacketBufferPoolSize(int size);
         IServiceCollection GetServiceCollection();
+        IClientBuilder SetServiceCollection(IServiceCollection serviceCollection, Func<IServiceProvider> serviceProviderFactory = null);
     }
 }

--- a/Networker/Client/Client.cs
+++ b/Networker/Client/Client.cs
@@ -3,7 +3,6 @@ using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
 using Networker.Client.Abstractions;
-using Networker.Common;
 using Networker.Common.Abstractions;
 
 namespace Networker.Client

--- a/Networker/Client/ClientBuilder.cs
+++ b/Networker/Client/ClientBuilder.cs
@@ -1,7 +1,5 @@
-﻿using System.Collections.Generic;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Networker.Client.Abstractions;
-using Networker.Common;
 using Networker.Common.Abstractions;
 
 namespace Networker.Client

--- a/Networker/Client/ClientBuilder.cs
+++ b/Networker/Client/ClientBuilder.cs
@@ -8,13 +8,9 @@ namespace Networker.Client
 {
     public class ClientBuilder : BuilderBase<IClientBuilder, IClient, ClientBuilderOptions>, IClientBuilder
     {
-        public ClientBuilder()
+        public ClientBuilder() : base()
         {
-            this.options = new ClientBuilderOptions();
-            this.serviceCollection = new ServiceCollection();
-            this.modules = new List<IPacketHandlerModule>();
-            this.module = new PacketHandlerModule();
-            this.modules.Add(this.module);
+
         }
 
         public override IClient Build()

--- a/Networker/Client/ClientBuilder.cs
+++ b/Networker/Client/ClientBuilder.cs
@@ -1,23 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
 using Networker.Client.Abstractions;
 using Networker.Common;
 using Networker.Common.Abstractions;
-using Networker.Server;
-using Networker.Server.Abstractions;
 
 namespace Networker.Client
 {
-    public class ClientBuilder : IClientBuilder
+    public class ClientBuilder : BuilderBase<IClientBuilder, IClient, ClientBuilderOptions>, IClientBuilder
     {
-        private readonly PacketHandlerModule module;
-        private readonly List<IPacketHandlerModule> modules;
-        private readonly ClientBuilderOptions options;
-        private IServiceCollection serviceCollection;
-        private Func<IServiceProvider> serviceProviderFactory;
-        private Type logger;
-
         public ClientBuilder()
         {
             this.options = new ClientBuilderOptions();
@@ -27,82 +17,20 @@ namespace Networker.Client
             this.modules.Add(this.module);
         }
 
-        public IClient Build()
+        public override IClient Build()
         {
-            var packetHandlers = new PacketHandlers();
-            foreach(var packetHandlerModule in this.modules)
-            {
-                foreach(var packetHandler in packetHandlerModule.GetPacketHandlers())
-                {
-                    this.serviceCollection.AddSingleton(packetHandler.Value);
-                }
-            }
-
-            this.serviceCollection.AddSingleton(this.options);
+            SetupSharedDependencies();
             this.serviceCollection.AddSingleton<IClient, Client>();
             this.serviceCollection.AddSingleton<IClientPacketProcessor, ClientPacketProcessor>();
-            this.serviceCollection.AddSingleton<IPacketHandlers>(packetHandlers);
-            this.serviceCollection.AddSingleton<ILogLevelProvider, LogLevelProvider>();
 
-            if(this.logger == null)
-                this.serviceCollection.AddSingleton<ILogger, NoOpLogger>();
-
-            var serviceProvider = this.serviceProviderFactory != null ? serviceProviderFactory.Invoke() : this.serviceCollection.BuildServiceProvider();
-
-            PacketSerialiserProvider.PacketSerialiser = serviceProvider.GetService<IPacketSerialiser>();
-            serviceProvider.GetService<ILogLevelProvider>().SetLogLevel(this.options.LogLevel);
-
-            foreach(var packetHandlerModule in this.modules)
-            {
-                foreach(var packetHandler in packetHandlerModule.GetPacketHandlers())
-                {
-                    packetHandlers.Add(PacketSerialiserProvider.PacketSerialiser.CanReadName ? packetHandler.Key.Name : "Default",
-                        (IPacketHandler)serviceProvider.GetService(packetHandler.Value));
-                }
-            }
-
-            if (!PacketSerialiserProvider.PacketSerialiser.CanReadName && packetHandlers.GetPacketHandlers().Count > 1)
-            {
-                throw new Exception("A PacketSerialiser which cannot identify a packet can only support up to one packet type");
-            }
+            var serviceProvider = GetServiceProvider();
 
             return serviceProvider.GetService<IClient>();
-        }
-
-        public IServiceCollection GetServiceCollection()
-        {
-            return this.serviceCollection;
-        }
-
-        public IClientBuilder RegisterPacketHandler<TPacket, TPacketHandler>()
-            where TPacket: class where TPacketHandler: IPacketHandler
-        {
-            this.module.AddPacketHandler<TPacket, TPacketHandler>();
-            return this;
-        }
-
-        public IClientBuilder RegisterPacketHandlerModule<T>()
-            where T: IPacketHandlerModule
-        {
-            this.modules.Add(Activator.CreateInstance<T>());
-            return this;
-        }
-
-        public IClientBuilder SetLogLevel(LogLevel logLevel)
-        {
-            this.options.LogLevel = logLevel;
-            return this;
         }
 
         public IClientBuilder SetPacketBufferPoolSize(int size)
         {
             this.options.ObjectPoolSize = size;
-            return this;
-        }
-
-        public IClientBuilder SetPacketBufferSize(int size)
-        {
-            this.options.PacketSizeBuffer = size;
             return this;
         }
 
@@ -112,44 +40,10 @@ namespace Networker.Client
             return this;
         }
 
-        public IClientBuilder SetServiceCollection(IServiceCollection serviceCollection, Func<IServiceProvider> serviceProviderFactory = null)
-        {
-            this.serviceCollection = serviceCollection;
-            this.serviceProviderFactory = serviceProviderFactory;
-            return this;
-        }
-
-        public IClientBuilder UseLogger<T>()
-            where T: class, ILogger
-        {
-            this.logger = typeof(T);
-            this.serviceCollection.AddSingleton<ILogger, T>();
-            return this;
-        }
-
-        public IClientBuilder UseLogger(ILogger logger)
-        {
-            this.logger = this.logger.GetType();
-            this.serviceCollection.AddSingleton<ILogger>(logger);
-            return this;
-        }
-
-        public IClientBuilder UseTcp(int port)
-        {
-            this.options.TcpPort = port;
-            return this;
-        }
-
         public IClientBuilder UseUdp(int port, int localPort)
         {
             this.options.UdpPort = port;
             this.options.UdpPortLocal = localPort;
-            return this;
-        }
-
-        public IClientBuilder UseUdp(int port)
-        {
-            this.options.UdpPort = port;
             return this;
         }
     }

--- a/Networker/Client/ClientBuilder.cs
+++ b/Networker/Client/ClientBuilder.cs
@@ -14,7 +14,8 @@ namespace Networker.Client
         private readonly PacketHandlerModule module;
         private readonly List<IPacketHandlerModule> modules;
         private readonly ClientBuilderOptions options;
-        private readonly ServiceCollection serviceCollection;
+        private IServiceCollection serviceCollection;
+        private Func<IServiceProvider> serviceProviderFactory;
         private Type logger;
 
         public ClientBuilder()
@@ -46,7 +47,7 @@ namespace Networker.Client
             if(this.logger == null)
                 this.serviceCollection.AddSingleton<ILogger, NoOpLogger>();
 
-            var serviceProvider = this.serviceCollection.BuildServiceProvider();
+            var serviceProvider = this.serviceProviderFactory != null ? serviceProviderFactory.Invoke() : this.serviceCollection.BuildServiceProvider();
 
             PacketSerialiserProvider.PacketSerialiser = serviceProvider.GetService<IPacketSerialiser>();
             serviceProvider.GetService<ILogLevelProvider>().SetLogLevel(this.options.LogLevel);
@@ -108,6 +109,13 @@ namespace Networker.Client
         public IClientBuilder UseIp(string ip)
         {
             this.options.Ip = ip;
+            return this;
+        }
+
+        public IClientBuilder SetServiceCollection(IServiceCollection serviceCollection, Func<IServiceProvider> serviceProviderFactory = null)
+        {
+            this.serviceCollection = serviceCollection;
+            this.serviceProviderFactory = serviceProviderFactory;
             return this;
         }
 

--- a/Networker/Client/ClientBuilderOptions.cs
+++ b/Networker/Client/ClientBuilderOptions.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using Networker.Common;
+﻿using Networker.Common;
+using Networker.Common.Abstractions;
 
 namespace Networker.Client
 {
-    public class ClientBuilderOptions
+    public class ClientBuilderOptions : IBuilderOptions
     {
         public ClientBuilderOptions()
         {

--- a/Networker/Client/ClientPacketProcessor.cs
+++ b/Networker/Client/ClientPacketProcessor.cs
@@ -4,8 +4,6 @@ using System.Text;
 using Networker.Client.Abstractions;
 using Networker.Common;
 using Networker.Common.Abstractions;
-using Networker.Server;
-using Networker.Server.Abstractions;
 
 namespace Networker.Client
 {

--- a/Networker/Common/Abstractions/BuilderBase.cs
+++ b/Networker/Common/Abstractions/BuilderBase.cs
@@ -22,6 +22,15 @@ namespace Networker.Common.Abstractions
 
         private Type logger = typeof(NoOpLogger);
 
+        public BuilderBase()
+        {
+            this.options = Activator.CreateInstance<TBuilderOptions>();
+            this.serviceCollection = new ServiceCollection();
+            this.modules = new List<IPacketHandlerModule>();
+            this.module = new PacketHandlerModule();
+            this.modules.Add(this.module);
+        }
+
         public abstract TResult Build();
 
         public IServiceCollection GetServiceCollection()

--- a/Networker/Common/Abstractions/BuilderBase.cs
+++ b/Networker/Common/Abstractions/BuilderBase.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Networker.Common.Abstractions

--- a/Networker/Common/Abstractions/BuilderBase.cs
+++ b/Networker/Common/Abstractions/BuilderBase.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Networker.Common.Abstractions
+{
+    public abstract class BuilderBase<TBuilder, TResult, TBuilderOptions> : IBuilder<TBuilder, TResult> 
+        where TBuilder : class, IBuilder<TBuilder, TResult>
+        where TBuilderOptions : class, IBuilderOptions
+    {
+        //Modules
+        protected PacketHandlerModule module;
+        protected List<IPacketHandlerModule> modules;
+
+        //Service Collection
+        protected IServiceCollection serviceCollection;
+        protected Func<IServiceProvider> serviceProviderFactory;
+
+        //Builder Options
+        protected TBuilderOptions options;
+
+        private Type logger = typeof(NoOpLogger);
+
+        public abstract TResult Build();
+
+        public IServiceCollection GetServiceCollection()
+        {
+            return this.serviceCollection;
+        }
+
+        public TBuilder SetServiceCollection(IServiceCollection serviceCollection, Func<IServiceProvider> serviceProviderFactory = null)
+        {
+            this.serviceCollection = serviceCollection;
+            this.serviceProviderFactory = serviceProviderFactory;
+            return this as TBuilder;
+        }
+
+        public TBuilder RegisterPacketHandler<TPacket, TPacketHandler>()
+            where TPacket : class
+            where TPacketHandler : IPacketHandler
+        {
+            this.module.AddPacketHandler<TPacket, TPacketHandler>();
+            return this as TBuilder;
+        }
+
+        public TBuilder RegisterPacketHandlerModule(IPacketHandlerModule packetHandlerModule)
+        {
+            this.modules.Add(packetHandlerModule);
+            return this as TBuilder;
+        }
+
+        public TBuilder RegisterPacketHandlerModule<T>() where T : IPacketHandlerModule
+        {
+            this.modules.Add(Activator.CreateInstance<T>());
+            return this as TBuilder;
+        }
+
+        public TBuilder SetLogLevel(LogLevel logLevel)
+        {
+            this.options.LogLevel = logLevel;
+            return this as TBuilder;
+        }
+
+        public TBuilder SetPacketBufferSize(int size)
+        {
+            this.options.PacketSizeBuffer = size;
+            return this as TBuilder;
+        }
+
+        public TBuilder UseLogger<T>() where T : class, ILogger
+        {
+            this.logger = typeof(T);
+            return this as TBuilder;
+        }
+
+        public TBuilder UseLogger(ILogger logger)
+        {
+            this.logger = logger.GetType();
+            return this as TBuilder;
+        }
+
+        public TBuilder UseTcp(int port)
+        {
+            this.options.TcpPort = port;
+            return this as TBuilder;
+        }
+
+        public TBuilder UseUdp(int port)
+        {
+            this.options.UdpPort = port;
+            return this as TBuilder;
+        }
+
+        protected void SetupSharedDependencies()
+        {
+            var packetHandlers = new PacketHandlers();
+            foreach (var packetHandlerModule in this.modules)
+            {
+                foreach (var packetHandler in packetHandlerModule.GetPacketHandlers())
+                {
+                    this.serviceCollection.AddSingleton(packetHandler.Value);
+                }
+            }
+
+            this.serviceCollection.AddSingleton<TBuilderOptions>(this.options);
+            this.serviceCollection.AddSingleton(typeof(ILogger), logger);
+            this.serviceCollection.AddSingleton<IPacketHandlers, PacketHandlers>();
+            this.serviceCollection.AddSingleton<ILogLevelProvider, LogLevelProvider>();
+        }
+
+        protected IServiceProvider GetServiceProvider()
+        {
+            var serviceProvider = this.serviceProviderFactory != null ? serviceProviderFactory.Invoke() : this.serviceCollection.BuildServiceProvider();
+
+            PacketSerialiserProvider.PacketSerialiser = serviceProvider.GetService<IPacketSerialiser>();
+            serviceProvider.GetService<ILogLevelProvider>().SetLogLevel(this.options.LogLevel);
+
+            IPacketHandlers packetHandlers = serviceProvider.GetService<IPacketHandlers>();
+            foreach (var packetHandlerModule in this.modules)
+            {
+                foreach (var packetHandler in packetHandlerModule.GetPacketHandlers())
+                {
+                    packetHandlers.Add(PacketSerialiserProvider.PacketSerialiser.CanReadName ? packetHandler.Key.Name : "Default",
+                        (IPacketHandler)serviceProvider.GetService(packetHandler.Value));
+                }
+            }
+
+            if (!PacketSerialiserProvider.PacketSerialiser.CanReadName && packetHandlers.GetPacketHandlers().Count > 1)
+            {
+                throw new Exception("A PacketSerialiser which cannot identify a packet can only support up to one packet type");
+            }
+
+            return serviceProvider;
+        }
+    }
+}

--- a/Networker/Common/Abstractions/IBuilder.cs
+++ b/Networker/Common/Abstractions/IBuilder.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using System;
+
+namespace Networker.Common.Abstractions
+{
+    public interface IBuilder<TBuilder, TResult>
+    {
+        //Build
+        TResult Build();
+
+        //Service Collection
+        IServiceCollection GetServiceCollection();
+        TBuilder SetServiceCollection(IServiceCollection serviceCollection, Func<IServiceProvider> serviceProviderFactory = null);
+
+        //Packet Handler
+        TBuilder RegisterPacketHandler<TPacket, TPacketHandler>()
+            where TPacket : class where TPacketHandler : IPacketHandler;
+        TBuilder RegisterPacketHandlerModule(IPacketHandlerModule packetHandlerModule);
+        TBuilder RegisterPacketHandlerModule<T>()
+            where T : IPacketHandlerModule;
+
+        //Logging
+        TBuilder SetLogLevel(LogLevel logLevel);
+        TBuilder UseLogger<T>()
+            where T : class, ILogger;
+        TBuilder UseLogger(ILogger logger);
+
+        //Tcp
+        TBuilder UseTcp(int port);
+
+        //Udp
+        TBuilder UseUdp(int port);
+
+        //Info
+        TBuilder SetPacketBufferSize(int size);
+    }
+}

--- a/Networker/Common/Abstractions/IBuilderOptions.cs
+++ b/Networker/Common/Abstractions/IBuilderOptions.cs
@@ -1,0 +1,11 @@
+﻿
+namespace Networker.Common.Abstractions
+{
+    public interface IBuilderOptions
+    {
+        int TcpPort { get; set; }
+        int UdpPort { get; set; }
+        int PacketSizeBuffer { get; set; }
+        LogLevel LogLevel { get; set; }
+    }
+}

--- a/Networker/Common/Abstractions/IPacketHandlers.cs
+++ b/Networker/Common/Abstractions/IPacketHandlers.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using Networker.Common.Abstractions;
+﻿using System.Collections.Generic;
 
-namespace Networker.Server.Abstractions
+namespace Networker.Common.Abstractions
 {
     public interface IPacketHandlers
     {

--- a/Networker/Common/PacketHandlers.cs
+++ b/Networker/Common/PacketHandlers.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Networker.Common.Abstractions;
-using Networker.Server.Abstractions;
 
-namespace Networker.Server
+namespace Networker.Common
 {
     public class PacketHandlers : IPacketHandlers
     {

--- a/Networker/Common/TcpSender.cs
+++ b/Networker/Common/TcpSender.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.Net;
+﻿using System.Net;
 using System.Net.Sockets;
-using Networker.Common;
 using Networker.Common.Abstractions;
 
-namespace Networker.Server
+namespace Networker.Common
 {
     public class TcpSender : ISender
     {

--- a/Networker/Common/UdpSender.cs
+++ b/Networker/Common/UdpSender.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Net;
-using Networker.Common;
+﻿using System.Net;
 using Networker.Common.Abstractions;
 
-namespace Networker.Server
+namespace Networker.Common
 {
     public class UdpSender : ISender
     {

--- a/Networker/Server/Abstractions/IBufferManager.cs
+++ b/Networker/Server/Abstractions/IBufferManager.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Net.Sockets;
+﻿using System.Net.Sockets;
 
 namespace Networker.Server.Abstractions
 {

--- a/Networker/Server/Abstractions/IBufferManager.cs
+++ b/Networker/Server/Abstractions/IBufferManager.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Net.Sockets;
 
-namespace Networker.Common.Abstractions
+namespace Networker.Server.Abstractions
 {
     public interface IBufferManager
     {

--- a/Networker/Server/Abstractions/IServerBuilder.cs
+++ b/Networker/Server/Abstractions/IServerBuilder.cs
@@ -1,43 +1,18 @@
-﻿using System;
-using Microsoft.Extensions.DependencyInjection;
-using Networker.Common;
-using Networker.Common.Abstractions;
+﻿using Networker.Common.Abstractions;
 
 namespace Networker.Server.Abstractions
 {
-    public interface IServerBuilder
+    public interface IServerBuilder : IBuilder<IServerBuilder, IServer>
     {
-        IServer Build();
-        IServiceCollection GetServiceCollection();
-
-        IServerBuilder RegisterPacketHandler<TPacket, TPacketHandler>()
-            where TPacket: class where TPacketHandler: IPacketHandler;
-
-        IServerBuilder RegisterPacketHandlerModule(IPacketHandlerModule packetHandlerModule);
-
-        IServerBuilder RegisterPacketHandlerModule<T>()
-            where T: IPacketHandlerModule;
-
-        IServerBuilder SetLogLevel(LogLevel logLevel);
-
-        IServerBuilder SetServiceCollection(IServiceCollection serviceCollection, Func<IServiceProvider> serviceProviderFactory = null);
-
-        IServerBuilder UseLogger<T>()
-            where T: class, ILogger;
-
-        IServerBuilder UseLogger(ILogger logger);
-        
-        IServerBuilder UseTcp(int port);
-
+        //Tcp
         IServerBuilder UseTcpSocketListener<T>()
             where T: class, ITcpSocketListenerFactory;
 
-        IServerBuilder UseUdp(int port);
-
+        //Udp
         IServerBuilder UseUdpSocketListener<T>()
             where T: class, IUdpSocketListenerFactory;
 
+        //Info
         IServerBuilder SetMaximumConnections(int maxConnections);
-        IServerBuilder SetPacketBufferSize(int packetBufferSize);
     }
 }

--- a/Networker/Server/Abstractions/IServerBuilder.cs
+++ b/Networker/Server/Abstractions/IServerBuilder.cs
@@ -20,7 +20,7 @@ namespace Networker.Server.Abstractions
 
         IServerBuilder SetLogLevel(LogLevel logLevel);
 
-        IServerBuilder SetServiceCollection(IServiceCollection serviceCollection);
+        IServerBuilder SetServiceCollection(IServiceCollection serviceCollection, Func<IServiceProvider> serviceProviderFactory = null);
 
         IServerBuilder UseLogger<T>()
             where T: class, ILogger;

--- a/Networker/Server/BufferManager.cs
+++ b/Networker/Server/BufferManager.cs
@@ -1,9 +1,8 @@
-﻿using System;
+﻿using Networker.Server.Abstractions;
 using System.Collections.Generic;
 using System.Net.Sockets;
-using Networker.Common.Abstractions;
 
-namespace Networker.Common
+namespace Networker.Server
 {
     public class BufferManager : IBufferManager
     {

--- a/Networker/Server/ServerBuilder.cs
+++ b/Networker/Server/ServerBuilder.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
-using Networker.Common;
 using Networker.Common.Abstractions;
 using Networker.Server.Abstractions;
 

--- a/Networker/Server/ServerBuilder.cs
+++ b/Networker/Server/ServerBuilder.cs
@@ -15,6 +15,7 @@ namespace Networker.Server
         private readonly ServerBuilderOptions options;
         private Type logger;
         private IServiceCollection serviceCollection;
+        private Func<IServiceProvider> serviceProviderFactory;
         private Type tcpSocketListenerFactory;
         private Type udpSocketListenerFactory;
 
@@ -60,7 +61,7 @@ namespace Networker.Server
             if(this.logger == null)
                 this.serviceCollection.AddSingleton<ILogger>(new NoOpLogger());
             
-            var serviceProvider = this.serviceCollection.BuildServiceProvider();
+            var serviceProvider = this.serviceProviderFactory != null ? serviceProviderFactory.Invoke() : this.serviceCollection.BuildServiceProvider();
 
             serviceProvider.GetService<ILogLevelProvider>().SetLogLevel(this.options.LogLevel);
 
@@ -126,9 +127,10 @@ namespace Networker.Server
             return this;
         }
 
-        public IServerBuilder SetServiceCollection(IServiceCollection serviceCollection)
+        public IServerBuilder SetServiceCollection(IServiceCollection serviceCollection, Func<IServiceProvider> serviceProviderFactory = null)
         {
             this.serviceCollection = serviceCollection;
+            this.serviceProviderFactory = serviceProviderFactory;
             return this;
         }
 

--- a/Networker/Server/ServerBuilder.cs
+++ b/Networker/Server/ServerBuilder.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Networker.Common;
 using Networker.Common.Abstractions;
@@ -8,14 +7,8 @@ using Networker.Server.Abstractions;
 
 namespace Networker.Server
 {
-    public class ServerBuilder : IServerBuilder
+    public class ServerBuilder : BuilderBase<IServerBuilder, IServer, ServerBuilderOptions>, IServerBuilder
     {
-        private readonly PacketHandlerModule module;
-        private readonly List<IPacketHandlerModule> modules;
-        private readonly ServerBuilderOptions options;
-        private Type logger;
-        private IServiceCollection serviceCollection;
-        private Func<IServiceProvider> serviceProviderFactory;
         private Type tcpSocketListenerFactory;
         private Type udpSocketListenerFactory;
 
@@ -28,24 +21,14 @@ namespace Networker.Server
             this.modules.Add(this.module);
         }
 
-        public IServer Build()
+        public override IServer Build()
         {
-            var packetHandlers = new PacketHandlers();
-            foreach(var packetHandlerModule in this.modules)
-            {
-                foreach(var packetHandler in packetHandlerModule.GetPacketHandlers())
-                {
-                    this.serviceCollection.AddSingleton(packetHandler.Value);
-                }
-            }
+            SetupSharedDependencies();
 
-            this.serviceCollection.AddSingleton(this.options);
-            this.serviceCollection.AddSingleton<IPacketHandlers>(packetHandlers);
             this.serviceCollection.AddSingleton<ITcpConnections, TcpConnections>();
             this.serviceCollection.AddSingleton<IServer, Server>();
             this.serviceCollection.AddSingleton<IServerInformation, ServerInformation>();
             this.serviceCollection.AddSingleton<IServerPacketProcessor, ServerPacketProcessor>();
-            this.serviceCollection.AddSingleton<ILogLevelProvider, LogLevelProvider>();
             this.serviceCollection.AddSingleton<IBufferManager>(new BufferManager(
                 this.options.PacketSizeBuffer * this.options.TcpMaxConnections * 5,
                 this.options.PacketSizeBuffer));
@@ -58,61 +41,10 @@ namespace Networker.Server
                 this.serviceCollection
                     .AddSingleton<IUdpSocketListenerFactory, DefaultUdpSocketListenerFactory>();
 
-            if(this.logger == null)
-                this.serviceCollection.AddSingleton<ILogger>(new NoOpLogger());
-            
-            var serviceProvider = this.serviceProviderFactory != null ? serviceProviderFactory.Invoke() : this.serviceCollection.BuildServiceProvider();
 
-            serviceProvider.GetService<ILogLevelProvider>().SetLogLevel(this.options.LogLevel);
-
-            PacketSerialiserProvider.PacketSerialiser = serviceProvider.GetService<IPacketSerialiser>();
-
-            foreach (var packetHandlerModule in this.modules)
-            {
-                foreach(var packetHandler in packetHandlerModule.GetPacketHandlers())
-                {
-                    packetHandlers.Add(PacketSerialiserProvider.PacketSerialiser.CanReadName ? packetHandler.Key.Name : "Default",
-                        (IPacketHandler)serviceProvider.GetService(packetHandler.Value));
-                }
-            }
-
-            if (!PacketSerialiserProvider.PacketSerialiser.CanReadName && packetHandlers.GetPacketHandlers().Count > 1)
-            {
-                throw new Exception("A PacketSerialiser which cannot identify a packet can only support up to one packet type");
-            }
+            var serviceProvider = GetServiceProvider();
 
             return serviceProvider.GetService<IServer>();
-        }
-
-        public IServiceCollection GetServiceCollection()
-        {
-            return this.serviceCollection;
-        }
-
-        public IServerBuilder RegisterPacketHandler<TPacket, TPacketHandler>()
-            where TPacket: class where TPacketHandler: IPacketHandler
-        {
-            this.module.AddPacketHandler<TPacket, TPacketHandler>();
-            return this;
-        }
-
-        public IServerBuilder RegisterPacketHandlerModule(IPacketHandlerModule packetHandlerModule)
-        {
-            this.modules.Add(packetHandlerModule);
-            return this;
-        }
-
-        public IServerBuilder RegisterPacketHandlerModule<T>()
-            where T: IPacketHandlerModule
-        {
-            this.modules.Add(Activator.CreateInstance<T>());
-            return this;
-        }
-
-        public IServerBuilder SetLogLevel(LogLevel logLevel)
-        {
-            this.options.LogLevel = logLevel;
-            return this;
         }
 
         public IServerBuilder SetMaximumConnections(int maxConnections)
@@ -121,51 +53,11 @@ namespace Networker.Server
             return this;
         }
 
-        public IServerBuilder SetPacketBufferSize(int packetBufferSize)
-        {
-            this.options.PacketSizeBuffer = packetBufferSize;
-            return this;
-        }
-
-        public IServerBuilder SetServiceCollection(IServiceCollection serviceCollection, Func<IServiceProvider> serviceProviderFactory = null)
-        {
-            this.serviceCollection = serviceCollection;
-            this.serviceProviderFactory = serviceProviderFactory;
-            return this;
-        }
-
-        public IServerBuilder UseLogger<T>()
-            where T: class, ILogger
-        {
-            this.logger = typeof(T);
-            this.serviceCollection.AddSingleton<ILogger, T>();
-            return this;
-        }
-
-        public IServerBuilder UseLogger(ILogger logger)
-        {
-            this.logger = logger.GetType();
-            this.serviceCollection.AddSingleton<ILogger>(logger);
-            return this;
-        }
-
-        public IServerBuilder UseTcp(int port)
-        {
-            this.options.TcpPort = port;
-            return this;
-        }
-
         public IServerBuilder UseTcpSocketListener<T>()
             where T: class, ITcpSocketListenerFactory
         {
             this.tcpSocketListenerFactory = typeof(T);
             this.serviceCollection.AddSingleton<ITcpSocketListenerFactory, T>();
-            return this;
-        }
-
-        public IServerBuilder UseUdp(int port)
-        {
-            this.options.UdpPort = port;
             return this;
         }
 

--- a/Networker/Server/ServerBuilder.cs
+++ b/Networker/Server/ServerBuilder.cs
@@ -12,13 +12,9 @@ namespace Networker.Server
         private Type tcpSocketListenerFactory;
         private Type udpSocketListenerFactory;
 
-        public ServerBuilder()
+        public ServerBuilder() : base()
         {
-            this.options = new ServerBuilderOptions();
-            this.serviceCollection = new ServiceCollection();
-            this.modules = new List<IPacketHandlerModule>();
-            this.module = new PacketHandlerModule();
-            this.modules.Add(this.module);
+
         }
 
         public override IServer Build()

--- a/Networker/Server/ServerBuilderOptions.cs
+++ b/Networker/Server/ServerBuilderOptions.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using Networker.Common;
+﻿using Networker.Common;
+using Networker.Common.Abstractions;
 
 namespace Networker.Server
 {
-    public class ServerBuilderOptions
+    public class ServerBuilderOptions : IBuilderOptions
     {
         public ServerBuilderOptions()
         {


### PR DESCRIPTION
Added optional argument on IServerBuilder.SetServiceCollection() for creating the IServiceProvider used in ServerBuilder. 

I may be missing something, but I wasn't sure how I could inject my own services into packet handlers using another IoC framework because I could't access what IServiceProvider was being used in the ServerBuilder to resolve them. Perhaps this is an acceptable solution? ;)

Example with DryIoc:

```
var dryIocContainer = new Container().WithCompositionRoot<CompositionRoot>();

var serviceCollection = new ServiceCollection();
var server = new ServerBuilder()
    .UseUdp(5000)
    .SetServiceCollection(serviceCollection, () =>
    {
        dryIocContainer = dryIocContainer.WithDependencyInjectionAdapter(serviceCollection);
        return dryIocContainer.BuildServiceProvider();
    })
    .RegisterPacketHandlerModule<DefaultPacketHandlerModule>()
    .UseZeroFormatter()
    .Build();

server.Start();
```