### PR TITLE
Fixed Packet Processing

### DIFF
--- a/Networker.Formatter.ZeroFormatter/ZeroFormatterPacketSerialiser.cs
+++ b/Networker.Formatter.ZeroFormatter/ZeroFormatterPacketSerialiser.cs
@@ -8,14 +8,19 @@ namespace Networker.Formatter.ZeroFormatter
 {
     public class ZeroFormatterPacketSerialiser : IPacketSerialiser
     {
-        public T Deserialise<T>(byte[] packetBytes)
-        {
-            return ZeroFormatterSerializer.Deserialize<T>(packetBytes);
-        }
 
         public T Deserialise<T>(byte[] packetBytes, int offset, int length)
         {
-            return default(T);
+            if (offset == 0 && length == 0)
+                return ZeroFormatterSerializer.Deserialize<T>(packetBytes);
+
+            if (length == 0)
+                length = packetBytes.Length - offset;
+
+            byte[] newPacketBytes = new byte[length];
+            Buffer.BlockCopy(packetBytes, offset, newPacketBytes, 0, length);
+                
+            return ZeroFormatterSerializer.Deserialize<T>(newPacketBytes);
         }
 
         public byte[] Serialise<T>(T packet)

--- a/Networker/Server/ServerPacketProcessor.cs
+++ b/Networker/Server/ServerPacketProcessor.cs
@@ -78,9 +78,8 @@ namespace Networker.Server
                     if (this.packetSerialiser.CanReadName)
                     {
                         packetTypeName = Encoding.ASCII.GetString(buffer, currentPosition, packetNameSize);
+                        currentPosition += packetNameSize;
                     }
-
-                    var packetHandler = this.packetHandlers.GetPacketHandlers()[packetTypeName];
 
                     if(string.IsNullOrEmpty(packetTypeName))
                     {
@@ -93,10 +92,7 @@ namespace Networker.Server
                         return;
                     }
 
-                    if (this.packetSerialiser.CanReadName)
-                    {
-                        currentPosition += packetNameSize;
-                    }
+                    var packetHandler = this.packetHandlers.GetPacketHandlers()[packetTypeName];
 
                     if(this.packetSerialiser.CanReadOffset)
                     {


### PR DESCRIPTION
The ClientPacketProcessor didn't find the right IPacketHandler due to an error in the code. This is now fixed and the packet processing code has been cleaned up (client and server code). 

When using ZeroFormatterPacketSerialiser the packet instance of PacketHandlerBase.Process(T packet, ISender sender) is null, this was because the deserialize method was not yet implemented, this is now implemented.

### Changes

**ClientPacketProcessor:**
- Ran multiple times do to buffer.Length to large => fixed by changing buffer size to the amount of the received byte.
- Packet name not found do to negation of if statement (!this.packetSerialiser.CanReadName => this.packetSerialiser.CanReadName)
- Ordered in logical order, to prevent unnecessary calculations.

**ServerPacketProcessor:**
- Ordered code and removed double if statement.

**ZeroFormatterPacketSerialiser:**
- Removed method 'Deserialise<T>(byte[] packetBytes)' due to not used, and not part of abstraction.
- Implmemented method 'Deserialise<T>(byte[] packetBytes, int offset, int length)'

#### I have tested both ZeroFormatter and ProtobufNet applications and everything seems to be working properly.