### PR TITLE
Decouple packet handlers from serialization

### DIFF
--- a/Networker.Example.MessagePack/DefaultPackets/ClientPingPacketHandler.cs
+++ b/Networker.Example.MessagePack/DefaultPackets/ClientPingPacketHandler.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Threading.Tasks;
+using Networker.Common;
+using Networker.Common.Abstractions;
+
+namespace Networker.Example.MessagePack.DefaultPackets
+{
+    public class ClientPingPacketHandler : PacketHandlerBase<PingPacket>
+    {
+        public ClientPingPacketHandler(IPacketSerialiser packetSerialiser)
+            : base(packetSerialiser) { }
+        
+        public override async Task Process(PingPacket packet, IPacketContext context)
+        {
+            var diff = DateTime.UtcNow.Subtract(packet.Time);
+            Console.WriteLine($"Ping is {diff.Milliseconds}ms");
+        }
+    }
+}

--- a/Networker.Example.MessagePack/DefaultPackets/DefaultPacketHandlerModule.cs
+++ b/Networker.Example.MessagePack/DefaultPackets/DefaultPacketHandlerModule.cs
@@ -1,0 +1,12 @@
+﻿using Networker.Common;
+
+namespace Networker.Example.MessagePack.DefaultPackets
+{
+	public class DefaultPacketHandlerModule : PacketHandlerModuleBase
+	{
+		public DefaultPacketHandlerModule()
+		{
+			this.AddPacketHandler<PingPacket, PingPacketHandler>();
+		}
+	}
+}

--- a/Networker.Example.MessagePack/DefaultPackets/PingPacket.cs
+++ b/Networker.Example.MessagePack/DefaultPackets/PingPacket.cs
@@ -1,0 +1,12 @@
+﻿using MessagePack;
+using System;
+
+namespace Networker.Example.MessagePack.DefaultPackets
+{
+    [MessagePackObject]
+    public class PingPacket
+    {
+        [Key(2)]
+        public virtual DateTime Time { get; set; }
+    }
+}

--- a/Networker.Example.MessagePack/DefaultPackets/PingPacketHandler.cs
+++ b/Networker.Example.MessagePack/DefaultPackets/PingPacketHandler.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Networker.Common;
+using Networker.Common.Abstractions;
+
+namespace Networker.Example.MessagePack.DefaultPackets
+{
+    public class PingPacketHandler : PacketHandlerBase<PingPacket>
+    {
+        private readonly ILogger logger;
+
+        public PingPacketHandler(ILogger<PingPacketHandler> logger, IPacketSerialiser serialiser)
+            : base(serialiser)
+        {
+            this.logger = logger;
+        }
+
+        public override async Task Process(PingPacket packet, IPacketContext context)
+        {
+            this.logger.LogDebug("Received a ping packet from " + context.Sender.EndPoint);
+        }
+    }
+}

--- a/Networker.Example.MessagePack/ExamplePacketHandlerModule.cs
+++ b/Networker.Example.MessagePack/ExamplePacketHandlerModule.cs
@@ -1,0 +1,13 @@
+﻿using Networker.Common;
+
+namespace Networker.Example.MessagePack
+{
+    public class ExamplePacketHandlerModule : PacketHandlerModuleBase
+    {
+        public ExamplePacketHandlerModule()
+        {
+            this.AddPacketHandler<TestPacketThing, TestPacketHandler>();
+            this.AddPacketHandler<TestPacketOtherThing, TestPacketHandler>();
+        }
+    }
+}

--- a/Networker.Example.MessagePack/Networker.Example.MessagePack.csproj
+++ b/Networker.Example.MessagePack/Networker.Example.MessagePack.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0-preview3.19153.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Networker.Formatter.MessagePack\Networker.Formatter.MessagePack.csproj" />
+    <ProjectReference Include="..\Networker\Networker.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="MessagePack">
+      <HintPath>C:\Program Files\dotnet\sdk\NuGetFallbackFolder\messagepack\1.7.3.4\lib\netstandard2.0\MessagePack.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+</Project>

--- a/Networker.Example.MessagePack/Program.cs
+++ b/Networker.Example.MessagePack/Program.cs
@@ -3,22 +3,22 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Networker.Client;
-using Networker.Example.ZeroFormatter.DefaultPackets;
-using Networker.Formatter.ZeroFormatter;
+using Networker.Example.MessagePack.DefaultPackets;
+using Networker.Formatter.MessagePack;
 using Networker.Server;
 
-namespace Networker.Example.ZeroFormatter
+namespace Networker.Example.MessagePack
 {
-    class Program
+	class Program
     {
         static void Main(string[] args)
         {
             var server = new ServerBuilder()
                             .UseTcp(1000)
                             .UseUdp(5000)
-                            .RegisterPacketHandlerModule<DefaultPacketHandlerModule>()
+							.RegisterPacketHandlerModule<DefaultPacketHandlerModule>()
                             .RegisterPacketHandlerModule<ExamplePacketHandlerModule>()
-                            .UseZeroFormatter()
+                            .UseMessagePack()
                             .ConfigureLogging(loggingBuilder =>
                                                 {
                                                     loggingBuilder.AddConsole();
@@ -64,7 +64,7 @@ namespace Networker.Example.ZeroFormatter
                                                     .UseUdp(5000)
                                                     .RegisterPacketHandler<PingPacket,
                                                         ClientPingPacketHandler>()
-                                                    .UseZeroFormatter()
+                                                    .UseMessagePack()
                                                     .Build();
 
                     client.Connect();

--- a/Networker.Example.MessagePack/TestPacketHandler.cs
+++ b/Networker.Example.MessagePack/TestPacketHandler.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.Extensions.Logging;
+using Networker.Common;
+using Networker.Common.Abstractions;
+using System.Threading.Tasks;
+
+namespace Networker.Example.MessagePack 
+{
+	public class TestPacketHandler : 
+		PacketHandlerBase,
+		IPacketHandler<TestPacketThing>,
+		IPacketHandler<TestPacketOtherThing> 
+	{
+		private readonly ILogger logger;
+
+        public TestPacketHandler(ILogger<TestPacketHandler> logger)
+        {
+            this.logger = logger;
+        }
+
+		public Task Process(TestPacketThing packet, IPacketContext context)
+		{
+			this.logger.LogDebug("Received a thing packet from " + context.Sender.EndPoint);
+			this.logger.LogDebug("Payload: " + packet.SomeString);
+			return Task.CompletedTask;
+		}
+
+		public Task Process(TestPacketOtherThing packet, IPacketContext context) 
+		{
+			this.logger.LogDebug("Received an other thing packet from " + context.Sender.EndPoint);
+			this.logger.LogDebug("Payload: " + packet.SomeInt);
+			return Task.CompletedTask;
+		}
+	}
+}

--- a/Networker.Example.MessagePack/TestPacketOtherThing.cs
+++ b/Networker.Example.MessagePack/TestPacketOtherThing.cs
@@ -1,0 +1,11 @@
+﻿using MessagePack;
+
+namespace Networker.Example.MessagePack 
+{
+	[MessagePackObject]
+	public class TestPacketOtherThing
+	{
+		[Key(2)]
+		public virtual int SomeInt { get; set; }
+	}
+}

--- a/Networker.Example.MessagePack/TestPacketThing.cs
+++ b/Networker.Example.MessagePack/TestPacketThing.cs
@@ -1,0 +1,11 @@
+﻿using MessagePack;
+
+namespace Networker.Example.MessagePack 
+{
+	[MessagePackObject]
+	public class TestPacketThing
+	{
+		[Key(2)]
+		public virtual string SomeString { get; set; }
+	}
+}

--- a/Networker.Formatter.MessagePack/MessagePackBuilderExtensions.cs
+++ b/Networker.Formatter.MessagePack/MessagePackBuilderExtensions.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Networker.Client.Abstractions;
+using Networker.Common.Abstractions;
+using Networker.Server.Abstractions;
+
+namespace Networker.Formatter.MessagePack 
+{
+	public static class MessagePackBuilderExtensions 
+	{
+		public static IServerBuilder UseMessagePack(this IServerBuilder serverBuilder)
+		{
+			var serviceCollection = serverBuilder.GetServiceCollection();
+			serviceCollection.AddSingleton<IPacketSerialiser, MessagePackPacketSerialiser>();
+
+			return serverBuilder;
+		}
+
+        public static IClientBuilder UseMessagePack(this IClientBuilder clientBuilder)
+        {
+            var serviceCollection = clientBuilder.GetServiceCollection();
+            serviceCollection.AddSingleton<IPacketSerialiser, MessagePackPacketSerialiser>();
+            return clientBuilder;
+        }
+	}
+}

--- a/Networker.Formatter.MessagePack/MessagePackPacketSerialiser.cs
+++ b/Networker.Formatter.MessagePack/MessagePackPacketSerialiser.cs
@@ -1,0 +1,88 @@
+﻿using MessagePack;
+using Networker.Common;
+using Networker.Common.Abstractions;
+using System;
+using System.IO;
+using System.Text;
+
+namespace Networker.Formatter.MessagePack 
+{
+	public class MessagePackPacketSerialiser : IPacketSerialiser 
+	{
+
+		private readonly ObjectPool<MemoryStream> memoryStreamObjectPool;
+
+		public MessagePackPacketSerialiser()
+        {
+            this.memoryStreamObjectPool = new ObjectPool<MemoryStream>(1500);
+
+            for(var i = 0; i < this.memoryStreamObjectPool.Capacity; i++)
+            {
+                this.memoryStreamObjectPool.Push(new MemoryStream());
+            }
+        }
+
+        public byte[] Package(string name, byte[] bytes)
+        {
+            return new byte[] { };
+        }
+
+		public bool CanReadOffset => true;
+        public bool CanReadName => true;
+        public bool CanReadLength => true;
+
+		public T Deserialise<T>(byte[] packetBytes)
+		{
+			var deserialized = MessagePackSerializer.Typeless.Deserialize(packetBytes);
+
+			return (T) deserialized;
+		}
+
+		public T Deserialise<T>(byte[] packetBytes, int offset, int length) 
+		{
+			var memoryStream = this.memoryStreamObjectPool.Pop();
+
+            memoryStream.SetLength(0);
+            memoryStream.Write(packetBytes, offset, length);
+
+            var deserialised = MessagePackSerializer.Typeless.Deserialize(memoryStream);
+
+            this.memoryStreamObjectPool.Push(memoryStream);
+
+            return (T) deserialised;
+		}
+
+		public byte[] Serialise<T>(T packet) 
+		{
+			var packetBytes = MessagePackSerializer.Typeless.Serialize(packet);
+			
+			var name = packet.GetType().Name;
+			var nameBytes = Encoding.ASCII.GetBytes(name);
+
+			var packetWithData = new byte[packetBytes.Length + 8 + nameBytes.Length];
+
+            var packetCountBytes = BitConverter.GetBytes(packetBytes.Length);
+            var packetNameCountBytes = BitConverter.GetBytes(nameBytes.Length);
+
+            int currentPosition = 0;
+
+            foreach(var nameByte in packetNameCountBytes)
+            {
+                packetWithData[currentPosition++] = nameByte;
+            }
+
+            foreach(var packetByte in packetCountBytes)
+            {
+                packetWithData[currentPosition++] = packetByte;
+            }
+
+            Buffer.BlockCopy(nameBytes, 0, packetWithData, currentPosition, nameBytes.Length);
+
+            currentPosition += nameBytes.Length;
+
+            Buffer.BlockCopy(packetBytes, 0, packetWithData, currentPosition, packetBytes.Length);
+
+            return packetWithData;
+		}
+	}
+}

--- a/Networker.Formatter.MessagePack/Networker.Formatter.MessagePack.csproj
+++ b/Networker.Formatter.MessagePack/Networker.Formatter.MessagePack.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MessagePack" Version="1.7.3.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Networker\Networker.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Networker.SerialiserTest/Networker.SerialiserTest.csproj
+++ b/Networker.SerialiserTest/Networker.SerialiserTest.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="protobuf-net" Version="2.3.14-alpha1" />
+    <PackageReference Include="ZeroFormatter" Version="1.6.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="MessagePack">
+      <HintPath>C:\Program Files\dotnet\sdk\NuGetFallbackFolder\messagepack\1.7.3.4\lib\netstandard2.0\MessagePack.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+</Project>

--- a/Networker.SerialiserTest/Program.cs
+++ b/Networker.SerialiserTest/Program.cs
@@ -1,0 +1,85 @@
+﻿using ProtoBuf;
+using MessagePack;
+using System;
+using System.IO;
+using ZeroFormatter;
+
+namespace Networker.SerialiserTest 
+{
+	[MessagePackObject]
+	[ProtoContract]
+	[ZeroFormattable]
+	public class TestClass 
+	{
+		[Key(1)]
+		[ProtoMember(1)]
+		[Index(1)]
+		public string SomeString { get; set; }
+
+		[Key(2)]
+		[ProtoMember(2)]
+		[Index(2)]
+		public int SomeInt { get; set; }
+	}
+
+	class Program 
+	{
+
+		static void Main(string[] args)
+		{
+			TestClass testClass = new TestClass 
+			{
+				SomeString = "Hello",
+				SomeInt = 10
+			};
+			
+			// Just works :)
+			TestMessagePack(testClass);
+
+			// Requires type so we can make it work :)
+			TestProtobuf(testClass);
+
+			// Requires generic so we cannot make it work :(
+			// Deprecated in favor of message pack anyways
+			TestZeroFormatter(testClass);
+		}
+
+		static void TestMessagePack(TestClass testClass) 
+		{
+			byte[] bytes = MessagePackSerializer.Typeless.Serialize(testClass);
+
+			object obj = MessagePackSerializer.Typeless.Deserialize(bytes);
+
+			Console.WriteLine(obj.GetType());
+		}
+
+		static void TestProtobuf(TestClass testClass) 
+		{
+			object input = testClass;
+			byte[] bytes;
+			using (var ms = new MemoryStream()) 
+			{
+				Serializer.Serialize(ms, input);
+				bytes = ms.ToArray();
+			}
+			
+			object obj;
+			using (var ms = new MemoryStream()) 
+			{
+				ms.Write(bytes, 0, bytes.Length);
+				obj = Serializer.Deserialize(typeof(TestClass), ms);
+			}
+
+			Console.WriteLine(obj.GetType());
+		}
+
+		static void TestZeroFormatter(TestClass testClass) 
+		{
+			byte[] bytes = ZeroFormatterSerializer.Serialize(testClass);
+
+			object obj = ZeroFormatterSerializer.Deserialize<TestClass>(bytes);
+
+			Console.WriteLine(obj.GetType());
+		}
+	}
+}

--- a/Networker.sln
+++ b/Networker.sln
@@ -21,6 +21,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Networker.Example.Protobuf.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GameServer", "GameServer\GameServer.csproj", "{4AA5A3F3-1085-46A6-98C9-BC8A75BF33FF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Networker.Formatter.MessagePack", "Networker.Formatter.MessagePack\Networker.Formatter.MessagePack.csproj", "{94E910D6-4791-403B-8AB5-D1376B3317EA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Networker.Example.MessagePack", "Networker.Example.MessagePack\Networker.Example.MessagePack.csproj", "{89EC0215-1A69-496D-9142-C2D6DE57188F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Networker.SerialiserTest", "Networker.SerialiserTest\Networker.SerialiserTest.csproj", "{E0812C0F-A051-404A-AD1E-FEC460665C20}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -59,6 +65,18 @@ Global
 		{4AA5A3F3-1085-46A6-98C9-BC8A75BF33FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4AA5A3F3-1085-46A6-98C9-BC8A75BF33FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4AA5A3F3-1085-46A6-98C9-BC8A75BF33FF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{94E910D6-4791-403B-8AB5-D1376B3317EA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{94E910D6-4791-403B-8AB5-D1376B3317EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{94E910D6-4791-403B-8AB5-D1376B3317EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{94E910D6-4791-403B-8AB5-D1376B3317EA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{89EC0215-1A69-496D-9142-C2D6DE57188F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{89EC0215-1A69-496D-9142-C2D6DE57188F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{89EC0215-1A69-496D-9142-C2D6DE57188F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{89EC0215-1A69-496D-9142-C2D6DE57188F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E0812C0F-A051-404A-AD1E-FEC460665C20}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E0812C0F-A051-404A-AD1E-FEC460665C20}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E0812C0F-A051-404A-AD1E-FEC460665C20}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E0812C0F-A051-404A-AD1E-FEC460665C20}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -68,6 +86,8 @@ Global
 		{8CEC54CE-7A32-43C2-93A9-EDDDE6A7CBDA} = {B2B344C1-EABE-41DD-B4BF-6FCAA2E4474D}
 		{1AC50FF8-E5F0-454C-A9D8-EF4A9F803674} = {B2B344C1-EABE-41DD-B4BF-6FCAA2E4474D}
 		{4AA5A3F3-1085-46A6-98C9-BC8A75BF33FF} = {B2B344C1-EABE-41DD-B4BF-6FCAA2E4474D}
+		{89EC0215-1A69-496D-9142-C2D6DE57188F} = {B2B344C1-EABE-41DD-B4BF-6FCAA2E4474D}
+		{E0812C0F-A051-404A-AD1E-FEC460665C20} = {B2B344C1-EABE-41DD-B4BF-6FCAA2E4474D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A022B3C8-E866-480E-82A5-17935BA812CC}

--- a/Networker/Common/Abstractions/IPacketHandler.cs
+++ b/Networker/Common/Abstractions/IPacketHandler.cs
@@ -1,11 +1,15 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
-namespace Networker.Common.Abstractions
+namespace Networker.Common.Abstractions 
 {
-    public interface IPacketHandler
+	public interface IPacketHandler
     {
         Task Handle(byte[] packet, IPacketContext packetContext);
         Task Handle(byte[] packet, int offset, int length, IPacketContext packetContext);
     }
+
+	public interface IPacketHandler<T>  : IPacketHandler where T : class
+	{
+		Task Process(T packet, IPacketContext context);
+	}
 }

--- a/Networker/Common/PacketHandlerBase.cs
+++ b/Networker/Common/PacketHandlerBase.cs
@@ -1,13 +1,39 @@
 ﻿using System;
+using System.Reflection;
 using System.Threading.Tasks;
 using Networker.Common.Abstractions;
 
 namespace Networker.Common
 {
-    public abstract class PacketHandlerBase<T> : IPacketHandler
+    public abstract class PacketHandlerBase<T> : PacketHandlerBase, IPacketHandler<T>
         where T: class
     {
-        public IPacketSerialiser PacketSerialiser { get; }
+		protected PacketHandlerBase(IPacketSerialiser packetSerialiser) : base(packetSerialiser)
+        {
+           
+        }
+
+        protected PacketHandlerBase() : base()
+        {
+            
+        }
+
+		public async override Task Handle(byte[] packet, IPacketContext context)
+        {
+            await this.Process(this.PacketSerialiser.Deserialise<T>(packet), context);
+        }
+
+        public async override Task Handle(byte[] packet, int offset, int length, IPacketContext context)
+        {
+            await this.Process(this.PacketSerialiser.Deserialise<T>(packet, offset, length), context);
+        }
+
+        public abstract Task Process(T packet, IPacketContext context);
+    }
+
+	public abstract class PacketHandlerBase : IPacketHandler
+	{
+		public IPacketSerialiser PacketSerialiser { get; }
 
         protected PacketHandlerBase(IPacketSerialiser packetSerialiser)
         {
@@ -19,16 +45,18 @@ namespace Networker.Common
             this.PacketSerialiser = PacketSerialiserProvider.Provide();
         }
 
-        public async Task Handle(byte[] packet, IPacketContext context)
+        public async virtual Task Handle(byte[] packetBytes, IPacketContext context)
         {
-            await this.Process(this.PacketSerialiser.Deserialise<T>(packet), context);
+			object packet = this.PacketSerialiser.Deserialise<object>(packetBytes);
+			MethodInfo method = GetType().GetMethod("Process", new Type[] { packet.GetType(), typeof(IPacketContext) } );
+			await (Task) method.Invoke(this, new object[] { packet, context });
         }
 
-        public async Task Handle(byte[] packet, int offset, int length, IPacketContext context)
+        public async virtual Task Handle(byte[] packetBytes, int offset, int length, IPacketContext context)
         {
-            await this.Process(this.PacketSerialiser.Deserialise<T>(packet, offset, length), context);
+			object packet = this.PacketSerialiser.Deserialise<object>(packetBytes, offset, length);
+			MethodInfo method = GetType().GetMethod("Process", new Type[] { packet.GetType(), typeof(IPacketContext) } );
+			await (Task) method.Invoke(this, new object[] { packet, context });
         }
-
-        public abstract Task Process(T packet, IPacketContext context);
-    }
+	}
 }


### PR DESCRIPTION
Prototype code for Networker.Formatter.MessagePack and decoupling packet handlers from serialization so that a packet handler can process multiple packets.

This code makes use of MessagePack's Typeless serialization. I added:

- Networker.Formatter.MessagePack
- Networker.Example.MessagePack
- Networker.SerialiserTest

The library modifications include:

- Adding `IPacketHandler<T>` which extends `IPacketHandler`
- Breaking `PacketHandlerBase` into a regular and generic version

As is, this code works with MessagePack, but it won't for Protobuf or Zero Formatter since it relies of Typeless serialization. We can make it work for Prototbuf simply by passing in the Type. But since Zero Formatter relies strictly on generics, so I don't think it will work with it. That being said, Zero Formatter has been superseded by MessagePack so how important is it for Networker to support Zero Formatter?

Ideally, we would completely defer deserialization to the packet processor and just make `PacketHandlerBase<T>` an empty class that inherits `IPacketHandler<T>` to prevent breaking changes.

Right now the `PacketHandlerBase.Handle` method makes use of reflection.. not sure if there's a better alternative. We can always cache a map of packet types to process methods and even precache on startup.

What do you think?