### PR TITLE
Prototype code for packet handler decorators

### DIFF
--- a/Demos/Demo.Decorators/AuthorizationHandlerDecorator.cs
+++ b/Demos/Demo.Decorators/AuthorizationHandlerDecorator.cs
@@ -1,0 +1,35 @@
+﻿using Networker.Common;
+using Networker.Common.Abstractions;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace Demo.Decorators 
+{
+	// TODO: Test and make sure works with inheritance and multiple methods
+	// Aka replace SomePacket with PacketBase and test on SomePacket and SomeOtherPacket
+	public class AuthorizationHandlerDecorator : PacketHandlerDecorator<SomePacket>
+    {
+        public override async Task Process(SomePacket packet, IPacketContext context)
+        {
+			Role userRole = Role.AuthenticatedUser; // Get from service
+			Role minimumRequiredRole = GetMinimumRequiredRole(packet);
+			if (userRole >= minimumRequiredRole) 
+			{
+				await ContinueProcessing(packet, context);
+			}
+        }
+
+		private Role GetMinimumRequiredRole(SomePacket packet) 
+		{
+			RequireRoleAttribute authorize = GetProcessMethodInfo(packet).GetCustomAttribute<RequireRoleAttribute>();
+			if (authorize == null) 
+			{
+				return Role.GuestUser; // No authorization required
+			} 
+			else
+			{
+				return authorize.Role;
+			}
+		}
+    }
+}

--- a/Demos/Demo.Decorators/AuthorizeAttribute.cs
+++ b/Demos/Demo.Decorators/AuthorizeAttribute.cs
@@ -1,0 +1,10 @@
+﻿using Networker.Common;
+using System;
+
+namespace Demo.Decorators
+{
+	public class AuthorizeAttribute : DecoratorAttribute 
+	{
+		public override Type[] Types => new Type[] { typeof(AuthorizationHandlerDecorator) };
+	}
+}

--- a/Demos/Demo.Decorators/Demo.Decorators.csproj
+++ b/Demos/Demo.Decorators/Demo.Decorators.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Networker\Networker.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Demos/Demo.Decorators/LogAttribute.cs
+++ b/Demos/Demo.Decorators/LogAttribute.cs
@@ -1,0 +1,10 @@
+﻿using Networker.Common;
+using System;
+
+namespace Demo.Decorators
+{
+	public class LogAttribute : DecoratorAttribute 
+	{
+		public override Type[] Types => new Type[] { typeof(LoggingHandlerDecorator) };
+	}
+}

--- a/Demos/Demo.Decorators/LoggingHandlerDecorator.cs
+++ b/Demos/Demo.Decorators/LoggingHandlerDecorator.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.Extensions.Logging;
+using Networker.Common;
+using Networker.Common.Abstractions;
+using System.Threading.Tasks;
+
+namespace Demo.Decorators 
+{
+	public class LoggingHandlerDecorator : PacketHandlerDecorator<SomePacket>
+    {
+		private readonly ILogger logger;
+
+        public LoggingHandlerDecorator(ILogger logger)
+        {
+            this.logger = logger;
+        }
+
+        public override async Task Process(SomePacket packet, IPacketContext context)
+        {
+			logger.LogInformation("Logging to fake database: SomePacket received, SomePacket.SomeString = " + packet.SomeString);
+			await ContinueProcessing(packet, context);
+        }
+    }
+}

--- a/Demos/Demo.Decorators/MeasureExecutionAttribute.cs
+++ b/Demos/Demo.Decorators/MeasureExecutionAttribute.cs
@@ -1,0 +1,10 @@
+﻿using Networker.Common;
+using System;
+
+namespace Demo.Decorators
+{
+	public class MeasureExecutionAttribute : DecoratorAttribute 
+	{
+		public override Type[] Types => new Type[] { typeof(MeasureExecutionHandlerDecorator) };
+	}
+}

--- a/Demos/Demo.Decorators/MeasureExecutionHandlerDecorator.cs
+++ b/Demos/Demo.Decorators/MeasureExecutionHandlerDecorator.cs
@@ -1,0 +1,27 @@
+﻿using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Networker.Common;
+using Networker.Common.Abstractions;
+
+namespace Demo.Decorators
+{
+    public class MeasureExecutionHandlerDecorator : PacketHandlerDecorator<SomePacket>
+    {
+		private readonly ILogger logger;
+
+        public MeasureExecutionHandlerDecorator(ILogger logger)
+        {
+            this.logger = logger;
+        }
+
+        public override async Task Process(SomePacket packet, IPacketContext context)
+        {
+			Stopwatch stopwatch = Stopwatch.StartNew();
+			await ContinueProcessing(packet, context);
+			stopwatch.Stop();
+			long elapsedMs = stopwatch.ElapsedMilliseconds;
+			logger.LogInformation("SomePacket took " + elapsedMs + " to process.");
+        }
+    }
+}

--- a/Demos/Demo.Decorators/Program.cs
+++ b/Demos/Demo.Decorators/Program.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.Extensions.Logging;
+using Networker.Server;
+using System;
+
+namespace Demo.Decorators 
+{
+	class Program
+    {
+        static void Main(string[] args)
+        {
+            var server = new ServerBuilder().
+				UseTcp(1000).
+				SetMaximumConnections(6000).
+				UseUdp(5000).
+				ConfigureLogging(loggingBuilder =>
+                {
+                    loggingBuilder.SetMinimumLevel(
+                        LogLevel.Debug);
+                }).
+				RegisterPacketHandlerModule<SomePacketHandlerModule>().
+				Build();
+
+            server.Start();
+           
+            Console.ReadLine();
+        }
+    }
+}

--- a/Demos/Demo.Decorators/RequireRoleAttribute.cs
+++ b/Demos/Demo.Decorators/RequireRoleAttribute.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Demo.Decorators
+{
+	public class RequireRoleAttribute : Attribute 
+	{
+		public Role Role { get; private set; }
+
+		public RequireRoleAttribute(Role role) 
+		{
+			Role = role;
+		}
+	}
+}

--- a/Demos/Demo.Decorators/Role.cs
+++ b/Demos/Demo.Decorators/Role.cs
@@ -1,0 +1,12 @@
+﻿namespace Demo.Decorators 
+{
+	public enum Role 
+	{
+		GuestUser,
+		AuthenticatedUser,
+		QATester,
+		Moderator,
+		Developer,
+		Administrator
+	}
+}

--- a/Demos/Demo.Decorators/SomePacket.cs
+++ b/Demos/Demo.Decorators/SomePacket.cs
@@ -1,0 +1,7 @@
+﻿namespace Demo.Decorators 
+{
+    public class SomePacket
+    {
+        public string SomeString { get; set; }
+    }
+}

--- a/Demos/Demo.Decorators/SomePacketHandler.cs
+++ b/Demos/Demo.Decorators/SomePacketHandler.cs
@@ -1,0 +1,41 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Networker.Common;
+using Networker.Common.Abstractions;
+
+namespace Demo.Decorators
+{
+	// Build in attribute
+	[Decorate(
+		typeof(AuthorizationHandlerDecorator),
+		typeof(LoggingHandlerDecorator),
+		typeof(MeasureExecutionHandlerDecorator))]
+
+	// -- or --
+
+	// Custom attributes
+	[Authorize, Log, MeasureExecution]
+    public class SomePacketHandler : PacketHandlerBase<SomePacket>
+    {
+        private readonly ILogger logger;
+
+        public SomePacketHandler(ILogger logger)
+        {
+            this.logger = logger;
+        }
+        
+		[RequireRole(Role.Administrator)] 
+        public override Task Process(SomePacket packet, IPacketContext context)
+        {
+			Thread.Sleep(1000); // To test measure execution time decorator
+            logger.LogInformation("Processing SomePacket.");
+			return Task.CompletedTask;
+        }
+
+		public string GetLog(SomePacket packet) 
+		{
+			return "Packet received with data: " + packet.SomeString;
+		}
+    }
+}

--- a/Demos/Demo.Decorators/SomePacketHandlerModule.cs
+++ b/Demos/Demo.Decorators/SomePacketHandlerModule.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Networker.Common;
+
+namespace Demo.Decorators
+{
+    public class SomePacketHandlerModule : PacketHandlerModuleBase
+    {
+        public SomePacketHandlerModule()
+        {
+            this.AddPacketHandler<SomePacket, SomePacketHandler>();
+        }
+    }
+}

--- a/Networker.sln
+++ b/Networker.sln
@@ -35,6 +35,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tutorial.Client", "Demos\Tu
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tutorial.Common", "Demos\Tutorial.Common\Tutorial.Common.csproj", "{D6542750-89CB-4D09-9E7B-EAAA392D4E5D}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Demo.Decorators", "Demos\Demo.Decorators\Demo.Decorators.csproj", "{AE162773-D7F0-44D7-A732-8743D08C9CC1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -93,6 +95,10 @@ Global
 		{D6542750-89CB-4D09-9E7B-EAAA392D4E5D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D6542750-89CB-4D09-9E7B-EAAA392D4E5D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D6542750-89CB-4D09-9E7B-EAAA392D4E5D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AE162773-D7F0-44D7-A732-8743D08C9CC1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AE162773-D7F0-44D7-A732-8743D08C9CC1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AE162773-D7F0-44D7-A732-8743D08C9CC1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AE162773-D7F0-44D7-A732-8743D08C9CC1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -110,6 +116,7 @@ Global
 		{6ADC9B53-4FB7-487A-8D61-CC4981C30269} = {84C88291-7FC8-47AC-84FA-9CF5DF39028C}
 		{F7226539-2B8F-492F-B9BD-DA81E298AE67} = {84C88291-7FC8-47AC-84FA-9CF5DF39028C}
 		{D6542750-89CB-4D09-9E7B-EAAA392D4E5D} = {84C88291-7FC8-47AC-84FA-9CF5DF39028C}
+		{AE162773-D7F0-44D7-A732-8743D08C9CC1} = {84C88291-7FC8-47AC-84FA-9CF5DF39028C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A022B3C8-E866-480E-82A5-17935BA812CC}

--- a/Networker/Common/DecorateAttribute.cs
+++ b/Networker/Common/DecorateAttribute.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Networker.Common 
+{
+	public class DecorateAttribute : DecoratorAttribute 
+	{
+		public override Type[] Types => types;
+
+		private readonly Type[] types;
+
+		public DecorateAttribute(params Type[] types) 
+		{
+			this.types = types;
+		}
+	}
+}

--- a/Networker/Common/DecoratorAttribute.cs
+++ b/Networker/Common/DecoratorAttribute.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Networker.Common 
+{
+	public abstract class DecoratorAttribute : Attribute
+	{
+		public abstract Type[] Types { get; }
+	}
+}

--- a/Networker/Common/PacketHandlerDecorator.cs
+++ b/Networker/Common/PacketHandlerDecorator.cs
@@ -1,0 +1,55 @@
+﻿using Networker.Common.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace Networker.Common
+{
+    public abstract class PacketHandlerDecorator<T> : PacketHandlerBase<T> where T: class
+    {
+		private PacketHandlerBase<T> decoratedHandler;
+		private Dictionary<Type, MethodInfo> processMethodInfoCache = new Dictionary<Type, MethodInfo>();
+
+		public void Decorate(PacketHandlerBase<T> handler) 
+		{
+			decoratedHandler = handler;
+		}
+
+		protected Task ContinueProcessing(T packet, IPacketContext context) 
+		{
+			return decoratedHandler.Process(packet, context);
+		}
+
+		protected MethodInfo GetProcessMethodInfo(T packet) 
+		{
+			return GetProcessMethodInfo(packet.GetType());
+		}
+
+		protected MethodInfo GetProcessMethodInfo<S>() where S : T 
+		{
+			return GetProcessMethodInfo(typeof(S));
+		}
+
+		protected MethodInfo GetProcessMethodInfo(Type packetType) 
+		{
+			if (processMethodInfoCache.ContainsKey(packetType)) 
+			{
+				return processMethodInfoCache[packetType];
+			}
+
+			MethodInfo processMethodInfo = null;
+			if (decoratedHandler is PacketHandlerDecorator<T> decoratorHandler)
+			{
+				processMethodInfo = decoratorHandler.GetProcessMethodInfo(packetType);
+			} 
+			else
+			{
+				Type[] processParameterTypes = new Type[] { packetType, typeof(IPacketContext) };
+				processMethodInfo = GetType().GetMethod("Process", processParameterTypes);
+			}
+			processMethodInfoCache.Add(packetType, processMethodInfo);
+			return processMethodInfo;
+		}
+    }
+}


### PR DESCRIPTION
I wanted to get feedback before continuing with the last step of wiring up the decorators.

I added 3 classes to Networker:

* **DecorateAttribute** - Helper attribute to assign decorators to handlers
  * Example: `Decorate[typeof(AuthorizationHandlerDecorator)]`
* **DecoratorAttribute** - Base attribute class for making custom attributes to assign decorators
  * Example: `[Authorize]`
* **PacketHandlerDecorator**

The attributes can get added to handlers and modules.

I put together `Demo.Decorators` to demonstrate how the features gets used. It does not function yet.

The last part I need to do is wire up the decorators on startup. Should do this in `BuilderBase.SetupSharedDependencies`?